### PR TITLE
Correct PATCH support #90

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,15 @@ class ApplicationController < ActionController::API
   include Roar::Rails::ControllerAdditions
   include Roar::Rails::ControllerAdditions::Render
 
+  class UnprocessableRequest < StandardError; end
+
+  rescue_from UnprocessableRequest, with: :render_unprocessable
+
   def render_not_found
     render json: {message: 'Resource not found'}, status: :not_found
+  end
+
+  def render_unprocessable
+    render json: { message: 'Invalid request' }, status: :unprocessable_entity
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -23,6 +23,10 @@ class ProductsController < ApplicationController
     param :body, :product, :writeProduct, :required, 'Product'
     response :ok, 'Success', :readProduct
     response :conflict, 'Conflict', :readProduct
+    response :unprocessable_entity,
+             'Unprocessable entity, for example because of an identifier '\
+             'code used elsewhere',
+             :readProduct
     response :bad_request
   end
 
@@ -33,6 +37,10 @@ class ProductsController < ApplicationController
     param :body, :product, :writeProduct, :required, 'Product'
     response :ok, 'Success', :readProduct
     response :conflict, 'Conflict', :readProduct
+    response :unprocessable_entity,
+             'Unprocessable entity, for example because of an identifier '\
+             'code used elsewhere',
+             :readProduct
     response :not_found
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,10 @@ class UsersController < ApplicationController
     param :body, :user, :writeUser, :required, 'User'
     response :ok, 'Success', :readUser
     response :conflict, 'Conflict', :readUser
+    response :unprocessable_entity,
+             'Unprocessable entity, for example because of an identifier '\
+             'code used elsewhere',
+             :readProduct
     response :bad_request
   end
 
@@ -29,6 +33,10 @@ class UsersController < ApplicationController
     param :body, :user, :writeUser, :required, 'User'
     response :ok, 'Success', :readUser
     response :conflict, 'Conflict', :readUser
+    response :unprocessable_entity,
+             'Unprocessable entity, for example because of an identifier '\
+             'code used elsewhere',
+             :readProduct
     response :not_found
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,7 +1,7 @@
 class Product < ActiveRecord::Base
   acts_as_taggable
 
-  has_many :identifiers, as: :identifiable, autosave: true
+  has_many :identifiers, as: :identifiable, dependent: :destroy, autosave: true
   has_many :pricings, dependent: :destroy, autosave: true
 
   def quantity

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ActiveRecord::Base
   acts_as_taggable
 
-  has_many :identifiers, as: :identifiable
+  has_many :identifiers, as: :identifiable, dependent: :destroy
   has_many :carts
 end

--- a/config/initializers/params_parsers.rb
+++ b/config/initializers/params_parsers.rb
@@ -6,7 +6,7 @@ ActionDispatch::Request.parameter_parsers = ActionDispatch::Request.parameter_pa
           raise StandardError.new "Expecting a hash or array"
         end
       rescue
-        raise ActionDispatch::ParamsParser::ParseError
+        raise ActionDispatch::Http::Parameters::ParseError
       end
     end
   }
@@ -20,7 +20,7 @@ class CatchJsonParseErrors
   def call(env)
     begin
       @app.call(env)
-    rescue ActionDispatch::ParamsParser::ParseError => error
+    rescue ActionDispatch::Http::Parameters::ParseError => error
       if env['action_dispatch.request.content_type'] == Mime[:json]
         error_output = "There was a problem in the JSON you submitted: #{error}"
         return [


### PR DESCRIPTION
Currently associated resource collections work additively, which especially means it is not possible to delete associated resources / resource associations through the API. This PR changes this to authoritative collections, i.e. after the creation/update exactly the associations passed in the request will remain.